### PR TITLE
Allow dependencies surrounded by parens

### DIFF
--- a/plyara.py
+++ b/plyara.py
@@ -301,8 +301,8 @@ class Parser(object):
 
                 # Import and androguard functions will have a lot going on while
                 # a simple rule reference should be preceded or followed by a connecting
-                # keyword or be by itself
-                if (previous_term or next_term) and (next_term not in ('and', 'or')) and (previous_term not in ('and', 'or')):
+                # keyword, be by itself, or be surrounded with parens.
+                if (previous_term or next_term) and (next_term not in ('and', 'or', ')')) and (previous_term not in ('and', 'or', '(')):
                     continue
 
                 # Check if reference is a variable for string iteration

--- a/tests/data/detect_dependencies_ruleset.yar
+++ b/tests/data/detect_dependencies_ruleset.yar
@@ -1,0 +1,109 @@
+/*
+   License:
+    This file contains rules licensed under the GNU-GPLv2 license (http://www.gnu.org/licenses/gpl-2.0.html)
+    Version 1-20180211, author:unixfreaxjp
+*/
+
+private rule is__osx
+{
+ meta:
+    date = "2018-02-12"
+    author = "@unixfreaxjp"
+ condition:
+    uint32(0) == 0xfeedface     or uint32(0) == 0xcafebabe
+    or uint32(0) == 0xbebafeca  or uint32(0) == 0xcefaedfe
+    or uint32(0) == 0xfeedfacf  or uint32(0) == 0xcffaedfe
+}
+
+private rule priv01 {
+ meta:
+    date = "2018-02-11"
+    author = "@unixfreaxjp"
+ strings:
+    $vara01 = { 73 3A 70 3A 00 }
+    $vara02 = "Usage: %s" fullword nocase wide ascii
+    $vara03 = "[ -s secret ]" fullword nocase wide ascii
+    $vara04 = "[ -p port ]" fullword nocase wide ascii
+ condition:
+    all of them
+}
+
+private rule priv03 {
+ meta:
+    date = "2018-02-10"
+    author = "@unixfreaxjp"
+ strings:
+    $varb01 = { 41 57 41 56 41 55 41 54 55 53 0F B6 06 }
+    $varb02 = { 48 C7 07 00 00 00 00 48 C7 47 08 00 00 }
+    $vard01 = { 55 48 89 E5 41 57 41 56 41 55 41 54 53 }
+    $vard02 = { 55 48 89 E5 48 C7 47 08 00 00 00 00 48 }
+    // can be added
+ condition:
+    (2 of ($varb*)) or (2 of ($vard*))
+}
+rule MALW_TinyShell_backconnect_OSX {
+ meta:
+    date = "2018-02-10"
+    author = "@unixfreaxjp"
+ condition:
+    is__osx
+    and priv01
+    and priv02
+    and priv03
+    and priv04
+    and filesize < 100KB
+}
+
+rule MALW_TinyShell_backconnect_ELF {
+ meta:
+    date = "2018-02-10"
+    author = "@unixfreaxjp"
+ condition:
+    is__elf
+    and priv01
+    and ((priv02)
+      or ((priv03)
+        or (priv04)))
+    and filesize < 100KB
+}
+
+rule MALW_TinyShell_backconnect_Gen {
+ meta:
+    date = "2018-02-11"
+    author = "@unixfreaxjp"
+ condition:
+    ((is__elf) or  (is__osx))
+    and priv01
+    and priv02
+    and filesize < 100KB
+}
+
+rule MALW_TinyShell_backdoor_Gen {
+ meta:
+    date = "2018-02-11"
+    author = "@unixfreaxjp"
+ condition:
+    ((is__elf) or  (is__osx))
+    and priv01
+    and filesize > 20KB
+}
+
+rule test_rule_01 {
+condition:
+    (is__elf)
+}
+
+rule test_rule_02 {
+condition:
+    is__osx and is__elf
+}
+
+rule test_rule_03 {
+condition:
+    is__osx
+}
+
+rule test_rule_04 {
+condition:
+    (is__elf or is__osx)
+}

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -62,6 +62,25 @@ class TestStaticMethods(unittest.TestCase):
 
         self.assertEquals(inputString, rebuilt_rules)
 
+    def test_detect_dependencies(self):
+        with open('tests/data/detect_dependencies_ruleset.yar', 'r') as f:
+            inputString = f.read()
+
+        result = Plyara().parse_string(inputString)
+
+        self.assertEquals(Plyara.detect_dependencies(result[0]), [])
+        self.assertEquals(Plyara.detect_dependencies(result[1]), [])
+        self.assertEquals(Plyara.detect_dependencies(result[2]), [])
+        self.assertEquals(Plyara.detect_dependencies(result[3]), ['is__osx', 'priv01', 'priv02', 'priv03', 'priv04'])
+        self.assertEquals(Plyara.detect_dependencies(result[4]), ['is__elf', 'priv01', 'priv02', 'priv03', 'priv04'])
+        self.assertEquals(Plyara.detect_dependencies(result[5]), ['is__elf', 'is__osx', 'priv01', 'priv02'])
+        self.assertEquals(Plyara.detect_dependencies(result[6]), ['is__elf', 'is__osx', 'priv01'])
+        self.assertEquals(Plyara.detect_dependencies(result[7]), ['is__elf'])
+        self.assertEquals(Plyara.detect_dependencies(result[8]), ['is__osx', 'is__elf'])
+        self.assertEquals(Plyara.detect_dependencies(result[9]), ['is__osx'])
+        self.assertEquals(Plyara.detect_dependencies(result[10]), ['is__elf', 'is__osx'])
+
+
 class TestRuleParser(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Possible fix for #13. Not sure this is what we want, because I don't know what the import/androguard conditions mentioned in the comment on line 302 would look like. A better fix might be to skip past parens when grabbing `previous_term` / `next_term` on line 290. That's more complicated though, so I'd rather not do it unless this fix fails on import/androguard conditions.

@Taskr could you take a look? This is from the YaraGuardian additions.