### PR TITLE
Minor updates for detect_imports method and tests

### DIFF
--- a/plyara.py
+++ b/plyara.py
@@ -255,16 +255,15 @@ class Parser(object):
         condition_terms = rule['condition_terms']
 
         for imp in Parser.IMPORT_OPTIONS:
-            imp_string = u"\"{}\"".format(imp)
             imp_module = u"{}.".format(imp)
 
-            if imp in condition_terms and imp_string not in detected_imports:
-                detected_imports.append(imp_string)
+            if imp in condition_terms and imp not in detected_imports:
+                detected_imports.append(imp)
 
-            elif imp_string not in detected_imports:
+            elif imp not in detected_imports:
                 for term in condition_terms:
                     if term.startswith(imp_module):
-                        detected_imports.append(imp_string)
+                        detected_imports.append(imp)
                         break
 
         return detected_imports

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -68,17 +68,17 @@ class TestStaticMethods(unittest.TestCase):
 
         result = Plyara().parse_string(inputString)
 
-        self.assertEquals(Plyara.detect_dependencies(result[0]), [])
-        self.assertEquals(Plyara.detect_dependencies(result[1]), [])
-        self.assertEquals(Plyara.detect_dependencies(result[2]), [])
-        self.assertEquals(Plyara.detect_dependencies(result[3]), ['is__osx', 'priv01', 'priv02', 'priv03', 'priv04'])
-        self.assertEquals(Plyara.detect_dependencies(result[4]), ['is__elf', 'priv01', 'priv02', 'priv03', 'priv04'])
-        self.assertEquals(Plyara.detect_dependencies(result[5]), ['is__elf', 'is__osx', 'priv01', 'priv02'])
-        self.assertEquals(Plyara.detect_dependencies(result[6]), ['is__elf', 'is__osx', 'priv01'])
-        self.assertEquals(Plyara.detect_dependencies(result[7]), ['is__elf'])
-        self.assertEquals(Plyara.detect_dependencies(result[8]), ['is__osx', 'is__elf'])
-        self.assertEquals(Plyara.detect_dependencies(result[9]), ['is__osx'])
-        self.assertEquals(Plyara.detect_dependencies(result[10]), ['is__elf', 'is__osx'])
+        self.assertEqual(Plyara.detect_dependencies(result[0]), [])
+        self.assertEqual(Plyara.detect_dependencies(result[1]), [])
+        self.assertEqual(Plyara.detect_dependencies(result[2]), [])
+        self.assertEqual(Plyara.detect_dependencies(result[3]), ['is__osx', 'priv01', 'priv02', 'priv03', 'priv04'])
+        self.assertEqual(Plyara.detect_dependencies(result[4]), ['is__elf', 'priv01', 'priv02', 'priv03', 'priv04'])
+        self.assertEqual(Plyara.detect_dependencies(result[5]), ['is__elf', 'is__osx', 'priv01', 'priv02'])
+        self.assertEqual(Plyara.detect_dependencies(result[6]), ['is__elf', 'is__osx', 'priv01'])
+        self.assertEqual(Plyara.detect_dependencies(result[7]), ['is__elf'])
+        self.assertEqual(Plyara.detect_dependencies(result[8]), ['is__osx', 'is__elf'])
+        self.assertEqual(Plyara.detect_dependencies(result[9]), ['is__osx'])
+        self.assertEqual(Plyara.detect_dependencies(result[10]), ['is__elf', 'is__osx'])
 
     def test_detect_imports(self):
         for imp in ('androguard', 'cuckoo', 'dotnet', 'elf', 'hash', 'magic', 'math', 'pe'):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -80,6 +80,13 @@ class TestStaticMethods(unittest.TestCase):
         self.assertEquals(Plyara.detect_dependencies(result[9]), ['is__osx'])
         self.assertEquals(Plyara.detect_dependencies(result[10]), ['is__elf', 'is__osx'])
 
+    def test_detect_imports(self):
+        for imp in ('androguard', 'cuckoo', 'dotnet', 'elf', 'hash', 'magic', 'math', 'pe'):
+            with open('tests/data/import_ruleset_{}.yar'.format(imp), 'r') as f:
+                inputString = f.read()
+            results = Plyara().parse_string(inputString)
+            for rule in results:
+                self.assertEqual(Plyara.detect_imports(rule), [imp])
 
 class TestRuleParser(unittest.TestCase):
 


### PR DESCRIPTION
- Modified the detect_imports method as it was adding unnecessary quotes in the output listing
- Added tests for the detect_imports method
- Updated deprecated "assertEquals" statements to use "assertEqual" instead for some tests