### PR TITLE
Account for bytestring newlines in lineno

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
   - "pip install coverage"
   - "pip install codacy-coverage"
   - "pip install collective.checkdocs Pygments"
+  - "python - c 'print(os.listdir(\'/home/travis/build/plyara/plyara/tests/data\'))'"
   - "python setup.py install"
-  - "echo $TRAVIS_BUILD_DIR"
 script:
   - nosetests --with-coverage --cover-package=plyara --cover-xml
   - python setup.py checkdocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - "pip install codacy-coverage"
   - "pip install collective.checkdocs Pygments"
   - "python setup.py install"
+  - "echo $TRAVIS_BUILD_DIR"
 script:
   - nosetests --with-coverage --cover-package=plyara --cover-xml
   - python setup.py checkdocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
   - "pip install coverage"
   - "pip install codacy-coverage"
   - "pip install collective.checkdocs Pygments"
-  - "python - c 'print(os.listdir(\'/home/travis/build/plyara/plyara/tests/data\'))'"
   - "python setup.py install"
 script:
   - nosetests --with-coverage --cover-package=plyara --cover-xml

--- a/plyara.py
+++ b/plyara.py
@@ -829,6 +829,13 @@ class Plyara(Parser):
                                   t.lexer.lineno, t.lexer.lexpos)
 
         t.lexer.begin('INITIAL')
+
+        # Account for newlines in bytestring.
+        if '\r\n' in t.value:
+            t.lexer.lineno += t.value.count('\r\n')
+        else:
+            t.lexer.lineno += t.value.count('\n')
+
         return t
 
     t_BYTESTRING_ignore = ' \r\n\t'

--- a/tests/data/windows_newline_ruleset.yar
+++ b/tests/data/windows_newline_ruleset.yar
@@ -1,0 +1,8 @@
+rule sample
+{
+strings:
+$ = { 00
+      00 }
+conditio:
+all of them
+}

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -864,7 +864,7 @@ class TestYaraRules(unittest.TestCase):
             try:
                 result = plyara.parse_string(inputRules)
             except ParseTypeError as e:
-                self.assertIn('line 7', e.message)
+                self.assertEqual(7, e.lineno)
                 raise e
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -869,7 +869,7 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        testfile = pathlib.Path().cwd().joinpath('data').joinpath('windows_newlines_ruleset.yar')
+        testfile = pathlib.Path().cwd().joinpath('tests').joinpath('data').joinpath('windows_newlines_ruleset.yar')
         with open(testfile, 'r') as f:
             inputRules = f.read()
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import codecs
 import unittest
+import pathlib
 
 from plyara import Plyara
 from plyara import ParseTypeError
@@ -868,7 +869,8 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        with open('data/windows_newlines_ruleset.yar', 'r') as f:
+        testfile = pathlib.Path().cwd().joinpath('data').joinpath('windows_newlines_ruleset.yar')
+        with open(testfile, 'r') as f:
             inputRules = f.read()
 
         plyara = Plyara()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -868,7 +868,7 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        with open('/home/travis/build/plyara/plyara/tests/data/windows_newlines_ruleset.yar', 'r') as f:
+        with open('tests/data/windows_newline_ruleset.yar', 'r') as f:
             inputRules = f.read()
 
         plyara = Plyara()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -867,6 +867,18 @@ class TestYaraRules(unittest.TestCase):
                 self.assertEqual(7, e.lineno)
                 raise e
 
+    def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
+        inputRules = 'rule sample {\r\nstrings: $ = { 00 \r\n00 }\r\nconditio: all of them }'
+
+        plyara = Plyara()
+
+        with self.assertRaises(ParseTypeError):
+            try:
+                result = plyara.parse_string(inputRules)
+            except ParseTypeError as e:
+                self.assertEqual(4, e.lineno)
+                raise e
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -7,6 +7,7 @@ import codecs
 import unittest
 
 from plyara import Plyara
+from plyara import ParseTypeError
 
 UNHANDLED_RULE_MSG = "Unhandled Test Rule: {}"
 
@@ -844,6 +845,27 @@ class TestYaraRules(unittest.TestCase):
         result = plyara.parse_string(inputRules)
 
         self.assertEqual(result, [])
+
+    def test_lineno_incremented_by_newlines_in_bytestring(self):
+        inputRules = r'''
+        rule sample
+        {
+            strings:
+                $ = { 00 00 00 00 00 00
+                      00 00 00 00 00 00 } //line 6
+            conditio: //fault
+                all of them
+        }
+        '''
+
+        plyara = Plyara()
+
+        with self.assertRaises(ParseTypeError):
+            try:
+                result = plyara.parse_string(inputRules)
+            except ParseTypeError as e:
+                self.assertIn('line 7', e.message)
+                raise e
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -868,7 +868,8 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        inputRules = 'rule sample {\r\nstrings: $ = { 00 \r\n00 }\r\nconditio: all of them }'
+        with open('tests/data/windows_newlines_ruleset.yar', 'r') as f:
+            inputRules = f.read()
 
         plyara = Plyara()
 
@@ -876,7 +877,7 @@ class TestYaraRules(unittest.TestCase):
             try:
                 result = plyara.parse_string(inputRules)
             except ParseTypeError as e:
-                self.assertEqual(4, e.lineno)
+                self.assertEqual(6, e.lineno)
                 raise e
 
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -868,7 +868,7 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        with open('../tests/data/windows_newlines_ruleset.yar', 'r') as f:
+        with open('/home/travis/build/plyara/plyara/tests/data/windows_newlines_ruleset.yar', 'r') as f:
             inputRules = f.read()
 
         plyara = Plyara()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -868,7 +868,7 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        with open('tests/data/windows_newlines_ruleset.yar', 'r') as f:
+        with open('data/windows_newlines_ruleset.yar', 'r') as f:
             inputRules = f.read()
 
         plyara = Plyara()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import codecs
 import unittest
-import pathlib
 
 from plyara import Plyara
 from plyara import ParseTypeError
@@ -869,8 +868,7 @@ class TestYaraRules(unittest.TestCase):
                 raise e
 
     def test_lineno_incremented_by_windows_newlines_in_bytestring(self):
-        testfile = pathlib.Path().cwd().joinpath('tests').joinpath('data').joinpath('windows_newlines_ruleset.yar')
-        with open(testfile, 'r') as f:
+        with open('../tests/data/windows_newlines_ruleset.yar', 'r') as f:
             inputRules = f.read()
 
         plyara = Plyara()


### PR DESCRIPTION
This corrects the specific problem reported in #35, but there may be other places we're missing newlines as well.