### PR TITLE
use environment markers for enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ here = path.abspath(path.dirname(__file__))
 with codecs.open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['ply>=3.11']
-if sys.version_info < (3, ):
-    install_requires.append('enum34')
-
 setup(
     name='plyara',
     version='1.4.0',
@@ -34,7 +30,10 @@ setup(
     ],
     keywords='malware analysis yara',
     py_modules=['plyara'],
-    install_requires=install_requires,
+    install_requires=[
+        'ply>=3.11',
+        'enum34;python_version<"3.4"',
+    ],
     entry_points={
         'console_scripts': [
             'plyara=plyara:main',


### PR DESCRIPTION
The current `setup.py` is flawed. It will install `enum34` even on recent python3 versions. This is fixed by using environment markers instead of an if statement in `setup.py`. https://stackoverflow.com/questions/21082091/install-requires-based-on-python-version

```
$ ./.venv/bin/pip --version
pip 18.1 from /home/andreas/tmp/plyara/.venv/lib/python3.7/site-packages/pip (python 3.7)
$ cat setup.py 
import setuptools
setuptools.setup(install_requires=['plyara'])
$ ./.venv/bin/pip install .
Processing /home/andreas/tmp/plyara
Collecting plyara (from UNKNOWN==0.0.0)
  Downloading https://files.pythonhosted.org/packages/0b/8e/e1d8e368313f9a54c8f6378b2da60a9474a37fdb232b286949cace07cef5/plyara-1.4.0-py2.py3-none-any.whl
Collecting ply>=3.11 (from plyara->UNKNOWN==0.0.0)
  Downloading https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl (49kB)
    100% |████████████████████████████████| 51kB 2.6MB/s 
Collecting enum34 (from plyara->UNKNOWN==0.0.0)
  Downloading https://files.pythonhosted.org/packages/af/42/cb9355df32c69b553e72a2e28daee25d1611d2c0d9c272aa1d34204205b2/enum34-1.1.6-py3-none-any.whl
Building wheels for collected packages: UNKNOWN
  Running setup.py bdist_wheel for UNKNOWN ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-04x88d42/wheels/eb/69/b0/385afb05151aa855cdd6e083a08ffc36b9b08f1dae7d556224
Successfully built UNKNOWN
Installing collected packages: ply, enum34, plyara, UNKNOWN
Successfully installed UNKNOWN-0.0.0 enum34-1.1.6 ply-3.11 plyara-1.4.0
```