### PR TITLE
Fix incorrect output on empty meta strings

### DIFF
--- a/plyara/core.py
+++ b/plyara/core.py
@@ -816,7 +816,7 @@ class Plyara(Parser):
         key = p[1]
         value = p[3]
         if re.match(r'".*"', value):
-            match = re.match('"(.+)"', value)
+            match = re.match('"(.*)"', value)
             if match:
                 value = match.group(1)
         elif value == 'true' or value == 'false':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1035,6 +1035,7 @@ class TestDeprecatedMethods(unittest.TestCase):  # REMOVE SOON!!
             meta:
                 string_value = "TEST STRING"
                 string_value = "DIFFERENT TEST STRING"
+                string_value = ""
                 bool_value = true
                 bool_value = false
                 digit_value = 5
@@ -1049,6 +1050,7 @@ class TestDeprecatedMethods(unittest.TestCase):  # REMOVE SOON!!
                 unparsed = Plyara.rebuild_yara_rule(rule)
             self.assertIn('string_value = "TEST STRING"', unparsed)
             self.assertIn('string_value = "DIFFERENT TEST STRING"', unparsed)
+            self.assertIn('string_value = ""', unparsed)
             self.assertIn('bool_value = true', unparsed)
             self.assertIn('bool_value = false', unparsed)
             self.assertIn('digit_value = 5', unparsed)


### PR DESCRIPTION
Also marked unit tests as non-executable, since Nose refuses to run them otherwise.

Closes #54.