### PR TITLE
Make parsing thread-safe

### DIFF
--- a/plyara/core.py
+++ b/plyara/core.py
@@ -241,7 +241,7 @@ class Parser:
             dict: All the parsed components of a YARA rule.
         """
         self._raw_input = input_string
-        yacc.parse(input_string)
+        self.parser.parse(input_string, lexer=self.lexer)
 
         for rule in self.rules:
             if any(self.imports):


### PR DESCRIPTION
The parsing is currently not thread safe and has random results when parse_string is called from multiple threads at once. Repro:

```python
import plyara
from concurrent.futures import ThreadPoolExecutor, as_completed

def run_plyara():
    parser = plyara.Plyara()
    rules = parser.parse_string("""rule silent_banker : banker
{
    meta:
        description = "This is just an example"
        thread_level = 3
        in_the_wild = true
    strings:
        $a = {6A 40 68 00 30 00 00 6A 14 8D 91}
        $b = {8D 4D B0 2B C1 83 C0 27 99 6A 4E 59 F7 F9}
        $c = "UVODFRYSIHLNWPEJXQZAKCBGMT"
    condition:
        $a or $b or $c
}
""" * 100)

with ThreadPoolExecutor(max_workers=4) as e:
    futures = []
    for i in range(16):
        futures.append(e.submit(run_plyara))

    for f in as_completed(futures):
        f.result()
```

Usually, it returns an exception.