### PR TITLE
Add option to clear the parser's state

### DIFF
--- a/plyara/core.py
+++ b/plyara/core.py
@@ -123,13 +123,27 @@ class Parser:
         self.parser = yacc.yacc(module=self, debug=False, outputdir=tempfile.gettempdir())
 
     def clear(self):
+        """Clear all information about previously parsed rules"""
         self.rules.clear()
-        #self.imports = set()
+
+        self.current_rule.clear()
+
+        self.string_modifiers.clear()
+        self.imports.clear()
         self.includes.clear()
         self.terms.clear()
         self.scopes.clear()
         self.tags.clear()
         self.comments.clear()
+
+        self._raw_input = None
+        self._meta_start = None
+        self._meta_end = None
+        self._strings_start = None
+        self._strings_end = None
+        self._condition_start = None
+        self._condition_end = None
+        self._rule_comments.clear()
 
     @staticmethod
     def _set_logging():

--- a/plyara/core.py
+++ b/plyara/core.py
@@ -122,6 +122,15 @@ class Parser:
         self.lexer = lex.lex(module=self, debug=False)
         self.parser = yacc.yacc(module=self, debug=False, outputdir=tempfile.gettempdir())
 
+    def clear(self):
+        self.rules.clear()
+        #self.imports = set()
+        self.includes.clear()
+        self.terms.clear()
+        self.scopes.clear()
+        self.tags.clear()
+        self.comments.clear()
+
     @staticmethod
     def _set_logging():
         """Set the console logger only if handler(s) aren't already set."""

--- a/tests/data/test_ruleset_1_rule.yar
+++ b/tests/data/test_ruleset_1_rule.yar
@@ -1,0 +1,9 @@
+// This ruleset is used for unit tests - Modification will require test updates
+
+rule rule_one
+{
+    strings:
+        $a = "one"
+    condition:
+        all of them
+}

--- a/tests/data/test_ruleset_2_rules.yar
+++ b/tests/data/test_ruleset_2_rules.yar
@@ -1,0 +1,17 @@
+// This ruleset is used for unit tests - Modification will require test updates
+
+rule rule_two
+{
+    strings:
+        $a = "two"
+    condition:
+        all of them
+}
+
+rule rule_three
+{
+    strings:
+        $a = "three"
+    condition:
+        all of them
+}

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -439,6 +439,31 @@ class TestRuleParser(unittest.TestCase):
             for fut in concurrent.futures.as_completed(futs):
                 self.assertEqual(len(fut.result()), 293)
 
+    def test_clear(self):
+        # instantiate parser
+        parser = Plyara()
+
+        # open a ruleset with one or more rules
+        with open('tests/data/test_ruleset_2_rules.yar', 'r') as fh:
+            inputRules = fh.read()
+
+        # parse the rules
+        parser.parse_string(inputRules)
+
+        # clear the parser's state
+        parser.clear()
+
+        # open a ruleset with one rule
+        with open('tests/data/test_ruleset_1_rule.yar', 'r') as fh:
+            inputRules = fh.read()
+
+        # parse the rules
+        result = parser.parse_string(inputRules)
+
+        # does the result contain just the rule from the second parse
+        assert len(result) == 1
+        assert result[0]['rule_name'] == 'rule_one'
+
 
 class TestYaraRules(unittest.TestCase):
 


### PR DESCRIPTION
This is a simple fix for #61 that adds a class method that can be called to clear several class member lists.  I have intentionally not cleared the imports list, since that is mentioned explicitly in the README.  But it should be a simple one-line change in the code if it makes sense for a clear() method to clear _all_ state.