### PR TITLE
Python38 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "3.6.9"
-  - "3.7.4"
+  - "3.7.6"
+  - "3.8.1"
 sudo: required
 dist: bionic
 install:

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@ Apache License
       identification within third-party archives.
 
    Copyright 2014 Christian Buia
-   Copyright 2019 plyara Maintainers
+   Copyright 2020 plyara Maintainers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plyara/__init__.py
+++ b/plyara/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/plyara/command_line.py
+++ b/plyara/command_line.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/plyara/core.py
+++ b/plyara/core.py
@@ -860,6 +860,7 @@ class Plyara(Parser):
 
         Args:
             p: Parser object.
+            string_type: StringTypes enum.
         """
         key = p[1]
         value = p[3]

--- a/plyara/core.py
+++ b/plyara/core.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/plyara/exceptions.py
+++ b/plyara/exceptions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/plyara/utils.py
+++ b/plyara/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='malware analysis yara',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright 2014 Christian Buia
-# Copyright 2019 plyara Maintainers
+# Copyright 2020 plyara Maintainers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fixes one docstring with a missing parameter definition and validates that everything passes CI on current Python versions including 3.8.1.