### PR TITLE
Minor changes to dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -U pip setuptools
 To install this package in development mode, please use the following command:
 
 ```
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 Additionally, if you wish to run the unit test suite, please use the following command:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ Please use the following commands to setup that virtualenv (for macOS and Linux)
 
 **NOTE: Development requires Python 3.7+**
 
-**NOTE: Command requires `jq` to be installed.**
-
 ```
 python3 -m venv venv
 source venv/bin/activate
-pip list -o --format json | jq -r '.[].name' | xargs -n 1 pip install -U
+pip install -U pip setuptools
 ```
 
 To install this package in development mode, please use the following command:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ It is recommended to create a virtual environment in the plyara directory for an
 
 Please use the following commands to setup that virtualenv (for macOS and Linux):
 
+**NOTE: Development requires Python 3.7+**
+
 **NOTE: Command requires `jq` to be installed.**
 
 ```
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 pip list -o --format json | jq -r '.[].name' | xargs -n 1 pip install -U
 ```


### PR DESCRIPTION
State that Python 3.7+ is required for dev, because of some of the unit tests.
Remove external tool dependency.
Add quotes to prevent accidental shell expansion.

Each of these changes is in its own commit, so I or you can easily revert one of the changes.