### PR TITLE
A bug dropping internal escaped double-quotes

### DIFF
--- a/src/plyara/core.py
+++ b/src/plyara/core.py
@@ -971,7 +971,7 @@ class Plyara(Parser):
         key = p[1]
         value = p[3]
         if re.match(r'".*"', value):
-            value = p[3][1:-1] if ( p[3][0] == '"' and p[3][-1] == '"') else p[3] # safe-strip double quotes
+            value = p[3].removeprefix('"').removesuffix('"')
         elif value in ('true', 'false'):
             value = True if value == 'true' else False
         elif value == '-':

--- a/src/plyara/core.py
+++ b/src/plyara/core.py
@@ -971,7 +971,7 @@ class Plyara(Parser):
         key = p[1]
         value = p[3]
         if re.match(r'".*"', value):
-            value = p[3].strip('"')
+            value = p[3][1:-1] if ( p[3][0] == '"' and p[3][-1] == '"') else p[3] # safe-strip double quotes
         elif value in ('true', 'false'):
             value = True if value == 'true' else False
         elif value == '-':

--- a/tests/data/core/metadata_ruleset.yar
+++ b/tests/data/core/metadata_ruleset.yar
@@ -4,6 +4,7 @@ rule StringTypeMetadata
 {
     meta:
         string_value = "String Metadata"
+        string_value2 = "String Metadata with \"ending quotes\""
 
     condition: false
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -308,9 +308,11 @@ class TestRuleParser(unittest.TestCase):
             kv_list = [(k,) + (v, ) for dic in kv for k, v in dic.items()]
 
             if rulename == 'StringTypeMetadata':
-                self.assertEqual(len(kv), 1)
+                self.assertEqual(len(kv), 2)
                 self.assertEqual(kv_list[0][0], 'string_value')
                 self.assertEqual(kv_list[0][1], 'String Metadata')
+                self.assertEqual(kv_list[1][0], 'string_value2')
+                self.assertEqual(kv_list[1][1], 'String Metadata with \\"ending quotes\\"')
 
             elif rulename == 'IntegerTypeMetadata':
                 self.assertEqual(len(kv), 1)


### PR DESCRIPTION
Fixed a bug which stripped escaped double-quotes in the end or possibly at the start of a string.
Extended a test file too.